### PR TITLE
Add support for Python 3.9, drop support for 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 language: python
 python:
-  - 2.7
+  - "2.7"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
   - pypy
-  - 3.5
-  - 3.6
-  - 3.7
-  - 3.8
   - pypy3
 
 matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,9 @@ CHANGES
 1.2 (unreleased)
 ----------------
 
-- Add support for Python 3.8.
+- Add support for Python 3.8 and 3.9.
 
-- Drop support for Python 3.4.
+- Drop support for Python 3.4 and 3.5.
 
 
 1.1 (2019-01-27)

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
@@ -66,6 +66,7 @@ setup(
         '!=3.2.*',
         '!=3.3.*',
         '!=3.4.*',
+        '!=3.5.*',
     ]),
     extras_require=dict(
         test=[

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
     lint,
     py27,
     pypy,
-    py35,
     py36,
     py37,
     py38,
+    py39,
     pypy3,
     coverage
 


### PR DESCRIPTION
This also fixes the broken `lint` environment.

modified:   .travis.yml
modified:   CHANGES.rst
modified:   setup.py
modified:   tox.ini